### PR TITLE
[update] 기본 OpenAPI URL 변경 및 SDK 버전 `1.5.1` 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ DataGSM의 OpenAPI를 추상화된 환경에서 제공합니다.
 <dependency>
     <groupId>com.github.themoment-team</groupId>
     <artifactId>datagsm-openapi-sdk-java</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
 </dependency>
 ```
 ### 설치 - Gradle
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.themoment-team:datagsm-openapi-sdk-java:1.5.0'
+    implementation 'com.github.themoment-team:datagsm-openapi-sdk-java:1.5.1'
 }
 ```
 
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.themoment-team:datagsm-openapi-sdk-java:1.5.0")
+    implementation("com.github.themoment-team:datagsm-openapi-sdk-java:1.5.1")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ dependencies {
 ```
 
 ### 사용법
-자세한 사용법은 [기술 문서](https://datagsm-front-docs.vercel.app/api/sdk/java)를 참고하십시오.
+자세한 사용법은 [기술 문서](https://docs.datagsm.kr/api/sdk/java)를 참고하십시오.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "team.themoment.datagsm.sdk"
-version = "1.5.0"
+version = "1.5.1"
 
 java {
     toolchain {

--- a/src/main/java/team/themoment/datagsm/sdk/openapi/DataGsmOpenApiClient.java
+++ b/src/main/java/team/themoment/datagsm/sdk/openapi/DataGsmOpenApiClient.java
@@ -8,7 +8,7 @@ import team.themoment.datagsm.sdk.openapi.http.OkHttpClientImpl;
  * DataGSM OpenAPI 메인 클라이언트
  */
 public class DataGsmOpenApiClient implements AutoCloseable {
-    private static final String DEFAULT_BASE_URL = "https://openapi.data.hellogsm.kr";
+    private static final String DEFAULT_BASE_URL = "https://openapi.datagsm.kr";
 
     private final HttpClient httpClient;
     private final StudentApi studentApi;


### PR DESCRIPTION
## Description
변경된 정식 OpenAPI URL을 기본값에 반영하고, SDK 버전 및 README 설치 예시를 1.5.1로 업데이트했습니다.

## Changes
- `DataGsmOpenApiClient`의 기본 Base URL을 `https://openapi.datagsm.kr`로 변경했습니다.
- SDK 버전을 `1.5.1`로 상향했습니다.
- README의 Maven/Gradle 설치 예시 버전을 `1.5.1`로 동기화했습니다.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Test update

## Checklist
- [x] 코드가 정상적으로 빌드됩니다
- [ ] 관련 테스트를 추가하거나 업데이트했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [ ] Breaking change가 있다면 마이그레이션 가이드를 작성했습니다

## Related Issues
N/A