### PR TITLE
[feat] 시간표 API 추가 및 급식·학사일정 응답 구조 변경 대응

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ DataGSM의 OpenAPI를 추상화된 환경에서 제공합니다.
 <dependency>
     <groupId>com.github.themoment-team</groupId>
     <artifactId>datagsm-openapi-sdk-java</artifactId>
-    <version>1.5.1</version>
+    <version>1.6.0</version>
 </dependency>
 ```
 ### 설치 - Gradle
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.themoment-team:datagsm-openapi-sdk-java:1.5.1'
+    implementation 'com.github.themoment-team:datagsm-openapi-sdk-java:1.6.0'
 }
 ```
 
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.themoment-team:datagsm-openapi-sdk-java:1.5.1")
+    implementation("com.github.themoment-team:datagsm-openapi-sdk-java:1.6.0")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "team.themoment.datagsm.sdk"
-version = "1.5.1"
+version = "1.6.0"
 
 java {
     toolchain {

--- a/src/main/java/team/themoment/datagsm/sdk/openapi/client/NeisApi.java
+++ b/src/main/java/team/themoment/datagsm/sdk/openapi/client/NeisApi.java
@@ -25,6 +25,14 @@ public interface NeisApi {
     List<Schedule> getSchedules(ScheduleRequest request);
 
     /**
+     * 시간표 정보 조회
+     *
+     * @param request 조회 조건
+     * @return 시간표 목록
+     */
+    List<Timetable> getTimetables(TimetableRequest request);
+
+    /**
      * 급식 요청 파라미터 빌더
      */
     class MealRequest {
@@ -47,6 +55,57 @@ public interface NeisApi {
         public MealRequest toDate(LocalDate toDate) {
             this.toDate = toDate;
             return this;
+        }
+
+        public LocalDate getDate() {
+            return date;
+        }
+
+        public LocalDate getFromDate() {
+            return fromDate;
+        }
+
+        public LocalDate getToDate() {
+            return toDate;
+        }
+    }
+
+    /**
+     * 시간표 요청 파라미터 빌더
+     */
+    class TimetableRequest {
+        private final int grade;
+        private final int classNum;
+        private LocalDate date;
+        private LocalDate fromDate;
+        private LocalDate toDate;
+
+        public TimetableRequest(int grade, int classNum) {
+            this.grade = grade;
+            this.classNum = classNum;
+        }
+
+        public TimetableRequest date(LocalDate date) {
+            this.date = date;
+            return this;
+        }
+
+        public TimetableRequest fromDate(LocalDate fromDate) {
+            this.fromDate = fromDate;
+            return this;
+        }
+
+        public TimetableRequest toDate(LocalDate toDate) {
+            this.toDate = toDate;
+            return this;
+        }
+
+        public int getGrade() {
+            return grade;
+        }
+
+        public int getClassNum() {
+            return classNum;
         }
 
         public LocalDate getDate() {

--- a/src/main/java/team/themoment/datagsm/sdk/openapi/client/NeisApiImpl.java
+++ b/src/main/java/team/themoment/datagsm/sdk/openapi/client/NeisApiImpl.java
@@ -32,9 +32,9 @@ public class NeisApiImpl implements NeisApi {
         Map<String, String> queryParams = buildMealQueryParams(request);
 
         String responseBody = httpClient.get(baseUrl + "/v1/neis/meals", headers, queryParams);
-        Type type = new TypeToken<CommonApiResponse<List<Meal>>>(){}.getType();
-        CommonApiResponse<List<Meal>> apiResponse = JsonUtil.fromJson(responseBody, type);
-        return apiResponse.getData();
+        Type type = new TypeToken<CommonApiResponse<MealResponseWrapper>>(){}.getType();
+        CommonApiResponse<MealResponseWrapper> apiResponse = JsonUtil.fromJson(responseBody, type);
+        return apiResponse.getData().meals;
     }
 
     @Override
@@ -43,9 +43,20 @@ public class NeisApiImpl implements NeisApi {
         Map<String, String> queryParams = buildScheduleQueryParams(request);
 
         String responseBody = httpClient.get(baseUrl + "/v1/neis/schedules", headers, queryParams);
-        Type type = new TypeToken<CommonApiResponse<List<Schedule>>>(){}.getType();
-        CommonApiResponse<List<Schedule>> apiResponse = JsonUtil.fromJson(responseBody, type);
-        return apiResponse.getData();
+        Type type = new TypeToken<CommonApiResponse<ScheduleResponseWrapper>>(){}.getType();
+        CommonApiResponse<ScheduleResponseWrapper> apiResponse = JsonUtil.fromJson(responseBody, type);
+        return apiResponse.getData().schedules;
+    }
+
+    @Override
+    public List<Timetable> getTimetables(TimetableRequest request) {
+        Map<String, String> headers = createHeaders();
+        Map<String, String> queryParams = buildTimetableQueryParams(request);
+
+        String responseBody = httpClient.get(baseUrl + "/v1/neis/timetables", headers, queryParams);
+        Type type = new TypeToken<CommonApiResponse<TimetableResponseWrapper>>(){}.getType();
+        CommonApiResponse<TimetableResponseWrapper> apiResponse = JsonUtil.fromJson(responseBody, type);
+        return apiResponse.getData().timetables;
     }
 
     private Map<String, String> buildMealQueryParams(MealRequest request) {
@@ -80,9 +91,40 @@ public class NeisApiImpl implements NeisApi {
         return params;
     }
 
+    private Map<String, String> buildTimetableQueryParams(TimetableRequest request) {
+        Map<String, String> params = new HashMap<>();
+
+        params.put("grade", String.valueOf(request.getGrade()));
+        params.put("classNum", String.valueOf(request.getClassNum()));
+
+        if (request.getDate() != null) {
+            params.put("date", request.getDate().format(DATE_FORMATTER));
+        }
+        if (request.getFromDate() != null) {
+            params.put("fromDate", request.getFromDate().format(DATE_FORMATTER));
+        }
+        if (request.getToDate() != null) {
+            params.put("toDate", request.getToDate().format(DATE_FORMATTER));
+        }
+
+        return params;
+    }
+
     private Map<String, String> createHeaders() {
         Map<String, String> headers = new HashMap<>();
         headers.put("X-API-KEY", apiKey);
         return headers;
+    }
+
+    private static class MealResponseWrapper {
+        List<Meal> meals;
+    }
+
+    private static class ScheduleResponseWrapper {
+        List<Schedule> schedules;
+    }
+
+    private static class TimetableResponseWrapper {
+        List<Timetable> timetables;
     }
 }

--- a/src/main/java/team/themoment/datagsm/sdk/openapi/model/Timetable.java
+++ b/src/main/java/team/themoment/datagsm/sdk/openapi/model/Timetable.java
@@ -1,0 +1,138 @@
+package team.themoment.datagsm.sdk.openapi.model;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+/**
+ * 시간표 정보
+ */
+public class Timetable {
+    private String timetableId;
+    private String schoolCode;
+    private String schoolName;
+    private String officeCode;
+    private String officeName;
+    private LocalDate timetableDate;
+    private String academicYear;
+    private String semester;
+    private int grade;
+    private int classNum;
+    private int period;
+    private String subject;
+
+    public Timetable() {}
+
+    public String getTimetableId() {
+        return timetableId;
+    }
+
+    public void setTimetableId(String timetableId) {
+        this.timetableId = timetableId;
+    }
+
+    public String getSchoolCode() {
+        return schoolCode;
+    }
+
+    public void setSchoolCode(String schoolCode) {
+        this.schoolCode = schoolCode;
+    }
+
+    public String getSchoolName() {
+        return schoolName;
+    }
+
+    public void setSchoolName(String schoolName) {
+        this.schoolName = schoolName;
+    }
+
+    public String getOfficeCode() {
+        return officeCode;
+    }
+
+    public void setOfficeCode(String officeCode) {
+        this.officeCode = officeCode;
+    }
+
+    public String getOfficeName() {
+        return officeName;
+    }
+
+    public void setOfficeName(String officeName) {
+        this.officeName = officeName;
+    }
+
+    public LocalDate getTimetableDate() {
+        return timetableDate;
+    }
+
+    public void setTimetableDate(LocalDate timetableDate) {
+        this.timetableDate = timetableDate;
+    }
+
+    public String getAcademicYear() {
+        return academicYear;
+    }
+
+    public void setAcademicYear(String academicYear) {
+        this.academicYear = academicYear;
+    }
+
+    public Optional<String> getSemester() {
+        return Optional.ofNullable(semester);
+    }
+
+    public void setSemester(String semester) {
+        this.semester = semester;
+    }
+
+    public int getGrade() {
+        return grade;
+    }
+
+    public void setGrade(int grade) {
+        this.grade = grade;
+    }
+
+    public int getClassNum() {
+        return classNum;
+    }
+
+    public void setClassNum(int classNum) {
+        this.classNum = classNum;
+    }
+
+    public int getPeriod() {
+        return period;
+    }
+
+    public void setPeriod(int period) {
+        this.period = period;
+    }
+
+    public Optional<String> getSubject() {
+        return Optional.ofNullable(subject);
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    @Override
+    public String toString() {
+        return "Timetable{" +
+                "timetableId='" + timetableId + '\'' +
+                ", schoolCode='" + schoolCode + '\'' +
+                ", schoolName='" + schoolName + '\'' +
+                ", officeCode='" + officeCode + '\'' +
+                ", officeName='" + officeName + '\'' +
+                ", timetableDate=" + timetableDate +
+                ", academicYear='" + academicYear + '\'' +
+                ", semester='" + semester + '\'' +
+                ", grade=" + grade +
+                ", classNum=" + classNum +
+                ", period=" + period +
+                ", subject='" + subject + '\'' +
+                '}';
+    }
+}


### PR DESCRIPTION
## Description
datagsm-server [PR #306](https://github.com/themoment-team/datagsm-server/pull/306) 변경사항에 대응하여 시간표 API를 추가하고, 급식·학사일정 응답 구조를 수정합니다.

## Changes
- `Timetable` 모델 추가 (`timetableId`, `schoolCode`, `schoolName`, `officeCode`, `officeName`, `timetableDate`, `academicYear`, `semester`, `grade`, `classNum`, `period`, `subject`)
- `NeisApi`에 `getTimetables(TimetableRequest)` 메서드 추가
- `TimetableRequest` 내부 클래스 추가 (`grade`, `classNum` 필수 / `date` 또는 `fromDate`+`toDate` 선택)
- `getMeals()` 응답 파싱 수정: 서버 응답 구조가 `List<Meal>` → `{ "meals": [...] }` 로 변경됨에 대응
- `getSchedules()` 응답 파싱 수정: 서버 응답 구조가 `List<Schedule>` → `{ "schedules": [...] }` 로 변경됨에 대응
- 버전 `1.5.1` → `1.6.0` 업데이트

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Test update

## Checklist
- [x] 코드가 정상적으로 빌드됩니다
- [ ] 관련 테스트를 추가하거나 업데이트했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [ ] Breaking change가 있다면 마이그레이션 가이드를 작성했습니다

## Related Issues
Closes #