### PR TITLE
[project] 프로젝트 상태 및 시작/종료 연도 필드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ DataGSM의 OpenAPI를 추상화된 환경에서 제공합니다.
 <dependency>
     <groupId>com.github.themoment-team</groupId>
     <artifactId>datagsm-openapi-sdk-java</artifactId>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
 </dependency>
 ```
 ### 설치 - Gradle
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.themoment-team:datagsm-openapi-sdk-java:1.6.0'
+    implementation 'com.github.themoment-team:datagsm-openapi-sdk-java:1.7.0'
 }
 ```
 
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.themoment-team:datagsm-openapi-sdk-java:1.6.0")
+    implementation("com.github.themoment-team:datagsm-openapi-sdk-java:1.7.0")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "team.themoment.datagsm.sdk"
-version = "1.6.0"
+version = "1.7.0"
 
 java {
     toolchain {

--- a/src/main/java/team/themoment/datagsm/sdk/openapi/model/Project.java
+++ b/src/main/java/team/themoment/datagsm/sdk/openapi/model/Project.java
@@ -11,6 +11,9 @@ public class Project {
     private Long id;
     private String name;
     private String description;
+    private int startYear;
+    private Integer endYear;
+    private ProjectStatus status;
     private Club club;
     private List<ParticipantInfo> participants = new ArrayList<>();
 
@@ -40,6 +43,30 @@ public class Project {
         this.description = description;
     }
 
+    public int getStartYear() {
+        return startYear;
+    }
+
+    public void setStartYear(int startYear) {
+        this.startYear = startYear;
+    }
+
+    public Optional<Integer> getEndYear() {
+        return Optional.ofNullable(endYear);
+    }
+
+    public void setEndYear(Integer endYear) {
+        this.endYear = endYear;
+    }
+
+    public ProjectStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ProjectStatus status) {
+        this.status = status;
+    }
+
     public Optional<Club> getClub() {
         return Optional.ofNullable(club);
     }
@@ -62,6 +89,9 @@ public class Project {
                 "id=" + id +
                 ", name='" + name + '\'' +
                 ", description='" + description + '\'' +
+                ", startYear=" + startYear +
+                ", endYear=" + endYear +
+                ", status=" + status +
                 ", club=" + club +
                 ", participants=" + participants +
                 '}';

--- a/src/main/java/team/themoment/datagsm/sdk/openapi/model/ProjectStatus.java
+++ b/src/main/java/team/themoment/datagsm/sdk/openapi/model/ProjectStatus.java
@@ -1,0 +1,16 @@
+package team.themoment.datagsm.sdk.openapi.model;
+
+/**
+ * 프로젝트 운영 상태
+ */
+public enum ProjectStatus {
+    /**
+     * 운영 중인 프로젝트
+     */
+    ACTIVE,
+
+    /**
+     * 종료된 프로젝트
+     */
+    ENDED
+}


### PR DESCRIPTION
## Description
<!-- 변경 사항을 간단히 설명해주세요 -->
[DataGSM PR #311](https://github.com/themoment-team/datagsm-server/pull/311)에서 `Project` 응답 스펙에 `startYear`, `endYear`, `status` 필드가 추가됨에 따라 Java SDK 모델을 동기화합니다.

## Changes
<!-- 주요 변경 내용을 나열해주세요 -->
- `Project` 모델에 다음 필드 및 접근자 추가
    - `int startYear`
    - `Integer endYear` (nullable, getter는 `Optional<Integer>` 반환)
    - `ProjectStatus status`
- `ProjectStatus` enum 신규 생성 (`ACTIVE`, `ENDED`)
- `Project#toString()`에 신규 필드 반영

## Type of Change
<!-- 해당하는 항목에 x를 표시해주세요 -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Checklist
- [x] 코드가 정상적으로 빌드됩니다
- [ ] 관련 테스트를 추가하거나 업데이트했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] Breaking change가 있다면 마이그레이션 가이드를 작성했습니다